### PR TITLE
Staff Recipe Fix

### DIFF
--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/StaffWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/StaffWrapper.java
@@ -15,8 +15,8 @@ public class StaffWrapper extends AbstractWandWrapper {
     @Override
     public Object[] genRecipe(CapWrapper cap) {
         return new Object[]{
-                "MCP",
-                "SRC",
+                "MSC",
+                "SRS",
                 "CSM",
                 'R', getCraftingRod(),
                 'M', getDetails().getConductor(),


### PR DESCRIPTION
![StafterOriginal](https://user-images.githubusercontent.com/14953816/116488170-b3648180-a85f-11eb-9070-0bb5cc3dfdae.png)
![StaffOriginal](https://user-images.githubusercontent.com/14953816/116488176-b5c6db80-a85f-11eb-8895-c0f7c1b848b0.png)
These are the current recipes for the Staff and Stafter. As they are identical, only the Staff can actually be crafted and doesn't follow the original Thaumcraft cap scheme.
![StaffFixed](https://user-images.githubusercontent.com/14953816/116488246-e1e25c80-a85f-11eb-8577-19f140287318.png)
This pull changes the basic Staff recipe to follow the wand scheme as it is in original Thaumcraft. The vis cost and screw tiering remains the same, or tier+1 relative to the wand core.