### PR TITLE
Major Wand/Scepter/Staff Rebalance

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,1 @@
-project.version=1.2.2
+project.version=1.2.3

--- a/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
@@ -24,7 +24,7 @@ public class GTWandRegistry implements IWandRegistry {
         new WandRecipeCreator("ice").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
         new WandRecipeCreator("quartz").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
         new WandRecipeCreator("bone").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("silverwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.6).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.7F);
+        new WandRecipeCreator("silverwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.6F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.75F);
         new WandRecipeCreator("primal").regStaffRecipe(175, 20, IV).regStaffSceptreRecipe(1.6F);
 
         TCWandAPI.regCap(new CapWrapper("iron", 0));

--- a/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
@@ -16,7 +16,7 @@ public class GTWandRegistry implements IWandRegistry {
 
     @Override
     public void register() {
-        new WandRecipeCreator("wood").regWandRecipe(0, 5, GT_ModHandler.getModItem("Forestry", "oakStick", 1, 0, new ItemStack(Items.stick)), GTTier.MV).regSceptreRecipe(2.0F);
+        new WandRecipeCreator("wood").regWandRecipe(0, 5, GT_ModHandler.getModItem("Forestry", "oakStick", 1, 0, new ItemStack(Items.stick)), GTTier.LV).regSceptreRecipe(2.0F);
         new WandRecipeCreator("greatwood").regWandRecipe(20, 5, MV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15).regStaffSceptreRecipe(1.4F);
         new WandRecipeCreator("reed").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
         new WandRecipeCreator("blaze").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);

--- a/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
@@ -17,15 +17,15 @@ public class GTWandRegistry implements IWandRegistry {
     @Override
     public void register() {
         new WandRecipeCreator("wood").regWandRecipe(0, 5, GT_ModHandler.getModItem("Forestry", "oakStick", 1, 0, new ItemStack(Items.stick)), GTTier.MV).regSceptreRecipe(2.0F);
-        new WandRecipeCreator("greatwood").regWandRecipe(20, 5, HV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15).regStaffSceptreRecipe(1.4F);
-        new WandRecipeCreator("reed").regWandRecipe(50, 10, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("blaze").regWandRecipe(50, 10, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("obsidian").regWandRecipe(50, 10, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("ice").regWandRecipe(50, 10, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("quartz").regWandRecipe(50, 10, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("bone").regStaffRecipe(125, 15, IV).regStaffSceptreRecipe(1.5F);//FIXME Why only staff?
-        new WandRecipeCreator("silverwood").regWandRecipe(75, 15, IV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
-        new WandRecipeCreator("primal").regStaffRecipe(175, 20, ZPM).regStaffSceptreRecipe(1.6F);
+        new WandRecipeCreator("greatwood").regWandRecipe(20, 5, MV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15).regStaffSceptreRecipe(1.4F);
+        new WandRecipeCreator("reed").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("blaze").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("obsidian").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("ice").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("quartz").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("bone").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("silverwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.65).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.75F);
+        new WandRecipeCreator("primal").regStaffRecipe(175, 20, IV).regStaffSceptreRecipe(1.6F);
 
         TCWandAPI.regCap(new CapWrapper("iron", 0));
         TCWandAPI.regCap(new CapWrapper("copper", 1));
@@ -38,11 +38,11 @@ public class GTWandRegistry implements IWandRegistry {
             TCWandsMod.LOGGER.info("Detected Forbidden Magic. Applying GTNH Recipes...");
             new WandRecipeCreator("profane").regWandRecipe(25, 5, HV).regSceptreRecipe(2F);
             new WandRecipeCreator("tainted").regWandRecipe(125, 15, IV).regSceptreRecipe(1.5F);
-            new WandRecipeCreator("blood").regWandRecipe(125, 15, IV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("blood").regWandRecipe(125, 15, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
             new WandRecipeCreator("infernal").regWandRecipe(125, 15, IV).regSceptreRecipe(1.5F);
-            new WandRecipeCreator("livingwood").regWandRecipe(75, 15, IV).regSceptreRecipe(1.4F);
-            new WandRecipeCreator("dreamwood").regWandRecipe(75, 15, IV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
-            new WandRecipeCreator("witchwood").regWandRecipe(75, 15, IV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("livingwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.4F);
+            new WandRecipeCreator("dreamwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("witchwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("manasteel", 5));
             TCWandAPI.regCap(new CapWrapper("terrasteel", 1));
@@ -60,7 +60,7 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.BLOOD_ARSENAL.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Blood Arsenal. Applying GTNH Recipes...");
-            new WandRecipeCreator("blood_wood").regWandRecipe(130, 15, IV).regSceptreRecipe(1.2F).regUpwardStaffRecipe(175, 20).regStaffSceptreRecipe(1.6F);
+            new WandRecipeCreator("blood_wood").regWandRecipe(130, 15, EV).regSceptreRecipe(1.2F).regUpwardStaffRecipe(175, 20).regStaffSceptreRecipe(1.6F);
 
             TCWandAPI.regCap(new CapWrapper("blood_iron", 6));
         }
@@ -71,7 +71,7 @@ public class GTWandRegistry implements IWandRegistry {
             TCWandAPI.makeCap("shadowcloth", GT_ModHandler.getModItem("TaintedMagic", "ItemWandCap", 1, 3), 0.85F, 7, new ResourceLocation("taintedmagic", "textures/models/ModelWAND_CAP_SHADOW_CLOTH.png"));
             TCWandAPI.makeCap("crimsoncloth", GT_ModHandler.getModItem("TaintedMagic", "ItemWandCap", 1, 2), 0.80F, 9, new ResourceLocation("taintedmagic", "textures/models/ModelWAND_CAP_CRIMSON_CLOTH.png"));
 
-            new WandRecipeCreator("warpwood").regWandRecipe(135, 15, IV).regSceptreRecipe(1.2F).regUpwardStaffRecipe(200, 25).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("warpwood").regWandRecipe(135, 15, LUV).regSceptreRecipe(1.2F).regUpwardStaffRecipe(200, 25).regStaffSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("cloth", 3));
             TCWandAPI.regCap(new CapWrapper("crimsoncloth", 6));
@@ -81,8 +81,8 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.THAUMIC_BASES.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Thaumic Bases. Applying GTNH Recipes...");
-            new WandRecipeCreator("tbthaumium").regWandRecipe(60, 10, EV).regSceptreRecipe(1.5F);
-            new WandRecipeCreator("tbvoid").regWandRecipe(160, 15, IV).regSceptreRecipe(1.2F);
+            new WandRecipeCreator("tbthaumium").regWandRecipe(60, 10, MV).regSceptreRecipe(1.5F);
+            new WandRecipeCreator("tbvoid").regWandRecipe(160, 15, HV).regSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("thauminite", 6));
         }
@@ -90,8 +90,8 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.THAUMIC_EXPLORATION.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Thaumic Exploration. Applying GTNH Recipes...");
-            new WandRecipeCreator("AMBER").regWandRecipe(20, 5, HV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15).regStaffSceptreRecipe(1.4F);
-            new WandRecipeCreator("TRANSMUTATION").regWandRecipe(50, 10, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+            new WandRecipeCreator("AMBER").regWandRecipe(20, 5, MV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15).regStaffSceptreRecipe(1.4F);
+            new WandRecipeCreator("TRANSMUTATION").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
             //FIXME where's NECROMANCER
             //cores.add(new WandCore("BREAD",HV, LICH, 20, 5, 2F));//FIXME need or not need?
 

--- a/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
@@ -37,9 +37,9 @@ public class GTWandRegistry implements IWandRegistry {
         if (CompatibleMods.FORBIDDEN_MAGIC.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Forbidden Magic. Applying GTNH Recipes...");
             new WandRecipeCreator("profane").regWandRecipe(25, 5, HV).regSceptreRecipe(2F);
-            new WandRecipeCreator("tainted").regWandRecipe(175, 15, IV).regSceptreRecipe(1.5F);
+            new WandRecipeCreator("tainted").regWandRecipe(175, 15, IV).regSceptreRecipe(1.3F);
             new WandRecipeCreator("blood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
-            new WandRecipeCreator("infernal").regWandRecipe(165, 15, IV).regSceptreRecipe(1.5F);
+            new WandRecipeCreator("infernal").regWandRecipe(165, 15, IV).regSceptreRecipe(1.35F);
             new WandRecipeCreator("livingwood").regWandRecipe(105, 15, EV).regSceptreRecipe(1.4F);
             new WandRecipeCreator("dreamwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
             new WandRecipeCreator("witchwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
@@ -81,8 +81,8 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.THAUMIC_BASES.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Thaumic Bases. Applying GTNH Recipes...");
-            new WandRecipeCreator("tbthaumium").regWandRecipe(60, 10, MV).regSceptreRecipe(1.5F);
-            new WandRecipeCreator("tbvoid").regWandRecipe(160, 15, HV).regSceptreRecipe(1.2F);
+            new WandRecipeCreator("tbthaumium").regWandRecipe(75, 10, HV).regSceptreRecipe(1.5F);
+            new WandRecipeCreator("tbvoid").regWandRecipe(175, 15, EV).regSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("thauminite", 6));
         }

--- a/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
@@ -18,14 +18,14 @@ public class GTWandRegistry implements IWandRegistry {
     public void register() {
         new WandRecipeCreator("wood").regWandRecipe(0, 5, GT_ModHandler.getModItem("Forestry", "oakStick", 1, 0, new ItemStack(Items.stick)), GTTier.LV).regSceptreRecipe(2.0F);
         new WandRecipeCreator("greatwood").regWandRecipe(20, 5, MV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15).regStaffSceptreRecipe(1.4F);
-        new WandRecipeCreator("reed").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("blaze").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("obsidian").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("ice").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("quartz").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("bone").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("silverwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.6F).regUpwardStaffRecipe(165, 15).regStaffSceptreRecipe(1.75F);
-        new WandRecipeCreator("primal").regStaffRecipe(175, 20, IV).regStaffSceptreRecipe(1.6F);
+        new WandRecipeCreator("reed").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("blaze").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("obsidian").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("ice").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("quartz").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("bone").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("silverwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.25F).regUpwardStaffRecipe(165, 15).regStaffSceptreRecipe(1.75F);
+        new WandRecipeCreator("primal").regStaffRecipe(175, 20, IV).regStaffSceptreRecipe(1.25F);
 
         TCWandAPI.regCap(new CapWrapper("iron", 0));
         TCWandAPI.regCap(new CapWrapper("copper", 1));
@@ -37,12 +37,12 @@ public class GTWandRegistry implements IWandRegistry {
         if (CompatibleMods.FORBIDDEN_MAGIC.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Forbidden Magic. Applying GTNH Recipes...");
             new WandRecipeCreator("profane").regWandRecipe(25, 5, HV).regSceptreRecipe(2F);
-            new WandRecipeCreator("tainted").regWandRecipe(175, 15, IV).regSceptreRecipe(1.3F);
-            new WandRecipeCreator("blood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("tainted").regWandRecipe(175, 15, IV).regSceptreRecipe(1.4F);
+            new WandRecipeCreator("blood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.35F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
             new WandRecipeCreator("infernal").regWandRecipe(165, 15, IV).regSceptreRecipe(1.35F);
-            new WandRecipeCreator("livingwood").regWandRecipe(105, 15, EV).regSceptreRecipe(1.4F);
-            new WandRecipeCreator("dreamwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
-            new WandRecipeCreator("witchwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("livingwood").regWandRecipe(105, 15, EV).regSceptreRecipe(1.35F);
+            new WandRecipeCreator("dreamwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.3F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("witchwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.3F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("manasteel", 5));
             TCWandAPI.regCap(new CapWrapper("terrasteel", 1));
@@ -53,7 +53,7 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.THAUMIC_TINKERER.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Thaumic Tinkerer. Applying GTNH Recipes...");
-            new WandRecipeCreator("ICHORCLOTH").regWandRecipe(250, 25, UV).regSceptreRecipe(1.2F);
+            new WandRecipeCreator("ICHORCLOTH").regWandRecipe(250, 25, UV).regSceptreRecipe(1.25F);
 
             TCWandAPI.regCap(new CapWrapper("ICHOR", 8));
         }

--- a/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
@@ -24,7 +24,7 @@ public class GTWandRegistry implements IWandRegistry {
         new WandRecipeCreator("ice").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
         new WandRecipeCreator("quartz").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
         new WandRecipeCreator("bone").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("silverwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.65).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.75F);
+        new WandRecipeCreator("silverwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.6).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.7F);
         new WandRecipeCreator("primal").regStaffRecipe(175, 20, IV).regStaffSceptreRecipe(1.6F);
 
         TCWandAPI.regCap(new CapWrapper("iron", 0));

--- a/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
@@ -18,13 +18,13 @@ public class GTWandRegistry implements IWandRegistry {
     public void register() {
         new WandRecipeCreator("wood").regWandRecipe(0, 5, GT_ModHandler.getModItem("Forestry", "oakStick", 1, 0, new ItemStack(Items.stick)), GTTier.MV).regSceptreRecipe(2.0F);
         new WandRecipeCreator("greatwood").regWandRecipe(20, 5, MV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15).regStaffSceptreRecipe(1.4F);
-        new WandRecipeCreator("reed").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("blaze").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("obsidian").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("ice").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("quartz").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("bone").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("silverwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.6F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.75F);
+        new WandRecipeCreator("reed").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("blaze").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("obsidian").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("ice").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("quartz").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("bone").regWandRecipe(60, 10, HV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
+        new WandRecipeCreator("silverwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.6F).regUpwardStaffRecipe(165, 15).regStaffSceptreRecipe(1.75F);
         new WandRecipeCreator("primal").regStaffRecipe(175, 20, IV).regStaffSceptreRecipe(1.6F);
 
         TCWandAPI.regCap(new CapWrapper("iron", 0));
@@ -37,12 +37,12 @@ public class GTWandRegistry implements IWandRegistry {
         if (CompatibleMods.FORBIDDEN_MAGIC.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Forbidden Magic. Applying GTNH Recipes...");
             new WandRecipeCreator("profane").regWandRecipe(25, 5, HV).regSceptreRecipe(2F);
-            new WandRecipeCreator("tainted").regWandRecipe(125, 15, IV).regSceptreRecipe(1.5F);
-            new WandRecipeCreator("blood").regWandRecipe(125, 15, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
-            new WandRecipeCreator("infernal").regWandRecipe(125, 15, IV).regSceptreRecipe(1.5F);
-            new WandRecipeCreator("livingwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.4F);
-            new WandRecipeCreator("dreamwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
-            new WandRecipeCreator("witchwood").regWandRecipe(75, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("tainted").regWandRecipe(175, 15, IV).regSceptreRecipe(1.5F);
+            new WandRecipeCreator("blood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.5F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("infernal").regWandRecipe(165, 15, IV).regSceptreRecipe(1.5F);
+            new WandRecipeCreator("livingwood").regWandRecipe(105, 15, EV).regSceptreRecipe(1.4F);
+            new WandRecipeCreator("dreamwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("witchwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("manasteel", 5));
             TCWandAPI.regCap(new CapWrapper("terrasteel", 1));
@@ -60,7 +60,7 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.BLOOD_ARSENAL.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Blood Arsenal. Applying GTNH Recipes...");
-            new WandRecipeCreator("blood_wood").regWandRecipe(130, 15, EV).regSceptreRecipe(1.2F).regUpwardStaffRecipe(175, 20).regStaffSceptreRecipe(1.6F);
+            new WandRecipeCreator("blood_wood").regWandRecipe(110, 15, EV).regSceptreRecipe(1.2F).regUpwardStaffRecipe(145, 20).regStaffSceptreRecipe(1.6F);
 
             TCWandAPI.regCap(new CapWrapper("blood_iron", 6));
         }
@@ -71,7 +71,7 @@ public class GTWandRegistry implements IWandRegistry {
             TCWandAPI.makeCap("shadowcloth", GT_ModHandler.getModItem("TaintedMagic", "ItemWandCap", 1, 3), 0.85F, 7, new ResourceLocation("taintedmagic", "textures/models/ModelWAND_CAP_SHADOW_CLOTH.png"));
             TCWandAPI.makeCap("crimsoncloth", GT_ModHandler.getModItem("TaintedMagic", "ItemWandCap", 1, 2), 0.80F, 9, new ResourceLocation("taintedmagic", "textures/models/ModelWAND_CAP_CRIMSON_CLOTH.png"));
 
-            new WandRecipeCreator("warpwood").regWandRecipe(135, 15, LUV).regSceptreRecipe(1.2F).regUpwardStaffRecipe(200, 25).regStaffSceptreRecipe(1.2F);
+            new WandRecipeCreator("warpwood").regWandRecipe(190, 15, LUV).regSceptreRecipe(1.2F).regUpwardStaffRecipe(220, 25).regStaffSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("cloth", 3));
             TCWandAPI.regCap(new CapWrapper("crimsoncloth", 6));

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
 
 public enum GTTier {
     LV(0, () -> GT_ModHandler.getModItem("TwilightForest", "item.nagaScale", 1, 0, new ItemStack(Items.wheat))),
-    MV(1, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
+    MV(1, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))), //This unfortunately creates a second Iron Capped Wooden Wand recipe via GTWandRegistry
     HV(2, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
     EV(3, () -> GT_ModHandler.getModItem("TwilightForest", "item.fieryBlood", 1, 0, new ItemStack(Items.potato))),
     IV(4, () -> GT_ModHandler.getModItem("TwilightForest", "item.fieryTears", 1, 0, new ItemStack(Items.poisonous_potato))),

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
@@ -9,8 +9,8 @@ import net.minecraft.item.ItemStack;
 import java.util.function.Supplier;
 
 public enum GTTier {
-    LV(0, () -> new ItemStack(Blocks.air)),
-    MV(1, () -> GT_ModHandler.getModItem("TwilightForest", "item.nagaScale", 1, 0, new ItemStack(Items.wheat))),
+    LV(0, () -> GT_ModHandler.getModItem("TwilightForest", "item.nagaScale", 1, 0, new ItemStack(Items.wheat))),
+    MV(1, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
     HV(2, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
     EV(3, () -> GT_ModHandler.getModItem("TwilightForest", "item.fieryBlood", 1, 0, new ItemStack(Items.potato))),
     IV(4, () -> GT_ModHandler.getModItem("TwilightForest", "item.fieryTears", 1, 0, new ItemStack(Items.poisonous_potato))),

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
@@ -16,7 +16,7 @@ public class WandDetails {
         tieredMaterials[0] = GTTier.values()[1].getGregTier().getMaterial();
         tieredMaterials[1] = Materials.StainlessSteel;
         tieredMaterials[2] = Materials.EnergeticAlloy;
-        tieredMaterials[3] = Materials.VividAlloy;
+        tieredMaterials[3] = Materials.VibrantAlloy;
         tieredMaterials[4] = Materials.TungstenSteel;
         tieredMaterials[5] = Materials.Enderium;
         tieredMaterials[6] = Materials.Oriharukon;

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
@@ -21,17 +21,17 @@ public class WandDetails {
         tieredMaterials[5] = Materials.Enderium;
         tieredMaterials[6] = Materials.Orharukon;
         tieredMaterials[7] = Materials.Osmiridium;
-        
+
         //fallback for any potential new tier in the GTTier enum
         for (int i=8; i<GTTier.values().length; i++){
-            tieredMaterials[7] = GTTier.values()[i].getGregTier().getMaterial(); ;
+            tieredMaterials[7] = GTTier.values()[i].getGregTier().getMaterial();
         }
     }
 
     public WandDetails(String name, GTTier tier, ItemStack conductor) {
         this.name = name;
         this.tier = tier;
-        this.material = tieredMaterials[tier.getIndex()]; 
+        this.material = tieredMaterials[tier.getIndex()];
         this.conductor = conductor;
     }
 

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
@@ -19,7 +19,7 @@ public class WandDetails {
         tieredMaterials[3] = Materials.VividAlloy;
         tieredMaterials[4] = Materials.TungstenSteel;
         tieredMaterials[5] = Materials.Enderium;
-        tieredMaterials[6] = Materials.Orharukon;
+        tieredMaterials[6] = Materials.Oriharukon;
         tieredMaterials[7] = Materials.Osmiridium;
 
         //fallback for any potential new tier in the GTTier enum

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
@@ -9,6 +9,24 @@ public class WandDetails {
     private Materials material;
     private GTTier tier;
     private ItemStack conductor;
+    private static Materials[] tieredMaterials;
+
+    static {
+        tieredMaterials = new Materials[GTTier.values().length];
+        tieredMaterials[0] = GTTier.values()[0].getGregTier().getMaterial();
+        tieredMaterials[1] = GTTier.values()[1].getGregTier().getMaterial();
+        tieredMaterials[2] = GTTier.values()[2].getGregTier().getMaterial();
+        tieredMaterials[3] = Materials.Ultimet;
+        tieredMaterials[4] = Materials.Titanium;
+        tieredMaterials[5] = Materials.TungstenSteel;
+        tieredMaterials[6] = Materials.HSSE;
+        tieredMaterials[7] = Materials.Osmiridium;
+        
+        //fallback for any potential new tier in the GTTier enum
+        for (int i=8; i<GTTier.values().length; i++){
+            tieredMaterials[7] = GTTier.values()[i].getGregTier().getMaterial();
+        }
+    }
 
     public WandDetails(String name, GTTier tier, ItemStack conductor) {
         this.name = name;

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
@@ -13,25 +13,25 @@ public class WandDetails {
 
     static {
         tieredMaterials = new Materials[GTTier.values().length];
-        tieredMaterials[0] = GTTier.values()[0].getGregTier().getMaterial();
-        tieredMaterials[1] = GTTier.values()[1].getGregTier().getMaterial();
-        tieredMaterials[2] = GTTier.values()[2].getGregTier().getMaterial();
-        tieredMaterials[3] = Materials.Ultimet;
-        tieredMaterials[4] = Materials.Titanium;
-        tieredMaterials[5] = Materials.TungstenSteel;
-        tieredMaterials[6] = Materials.HSSE;
+        tieredMaterials[0] = GTTier.values()[1].getGregTier().getMaterial();
+        tieredMaterials[1] = Materials.StainlessSteel;
+        tieredMaterials[2] = Materials.EnergeticAlloy;
+        tieredMaterials[3] = Materials.VividAlloy;
+        tieredMaterials[4] = Materials.TungstenSteel;
+        tieredMaterials[5] = Materials.Enderium;
+        tieredMaterials[6] = Materials.Orharukon;
         tieredMaterials[7] = Materials.Osmiridium;
         
         //fallback for any potential new tier in the GTTier enum
         for (int i=8; i<GTTier.values().length; i++){
-            tieredMaterials[7] = GTTier.values()[i].getGregTier().getMaterial();
+            tieredMaterials[7] = GTTier.values()[i].getGregTier().getMaterial(); ;
         }
     }
 
     public WandDetails(String name, GTTier tier, ItemStack conductor) {
         this.name = name;
         this.tier = tier;
-        this.material = tier.getGregTier().getMaterial();
+        this.material = tieredMaterials[tier.getIndex()]; 
         this.conductor = conductor;
     }
 


### PR DESCRIPTION
With some immensely wonderful help from @boubou19, this now allows for more free changes for material balancing and consideration. Majorly rebalances the wand material and changes some tiering for some wands, most notably the six primal wands before & also Silverwood, and especially Warp Wood. Thoughts are very much appreciated on the balancing so far.

I religiously tested this before creating the pull request.

**Tiered materials that is loaded for the game:**
LV = Aluminium (Ironwood Wand/Scepter/Staff)
MV = Stainless Steel (Greatwood)
HV = Energetic Alloy
EV = Vibrant Alloy
IV = Tungstensteel (Primal Staff)
LuV = Enderium (Warpwood)
ZPM = Oriharukon (Warpwood Staff)
UV = Osmiridium = (Ichorium)

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8314