### PR TITLE
Wand rebalance

### DIFF
--- a/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/GTWandRegistry.java
@@ -22,24 +22,24 @@ public class GTWandRegistry implements IWandRegistry {
                 0,
                 5,
                 GT_ModHandler.getModItem("Forestry", "oakStick", 1, 0, new ItemStack(Items.stick)),
-                GTTier.LV).regSceptreRecipe(2.0F);
-        new WandRecipeCreator("greatwood").regWandRecipe(20, 5, MV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15)
+                GTTier.STEAM).regSceptreRecipe(2.0F);
+        new WandRecipeCreator("greatwood").regWandRecipe(20, 5, LV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15)
                 .regStaffSceptreRecipe(1.4F);
-        new WandRecipeCreator("reed").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
+        new WandRecipeCreator("reed").regWandRecipe(60, 10, MV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
                 .regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("blaze").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
+        new WandRecipeCreator("blaze").regWandRecipe(60, 10, MV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
                 .regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("obsidian").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
+        new WandRecipeCreator("obsidian").regWandRecipe(60, 10, MV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
                 .regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("ice").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
+        new WandRecipeCreator("ice").regWandRecipe(60, 10, MV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
                 .regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("quartz").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
+        new WandRecipeCreator("quartz").regWandRecipe(60, 10, MV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
                 .regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("bone").regWandRecipe(60, 10, HV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
+        new WandRecipeCreator("bone").regWandRecipe(60, 10, MV).regSceptreRecipe(1.4F).regUpwardStaffRecipe(125, 15)
                 .regStaffSceptreRecipe(1.5F);
-        new WandRecipeCreator("silverwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.25F)
+        new WandRecipeCreator("silverwood").regWandRecipe(115, 15, HV).regSceptreRecipe(1.25F)
                 .regUpwardStaffRecipe(165, 15).regStaffSceptreRecipe(1.75F);
-        new WandRecipeCreator("primal").regStaffRecipe(175, 20, IV).regStaffSceptreRecipe(1.25F);
+        new WandRecipeCreator("primal").regStaffRecipe(175, 20, EV).regStaffSceptreRecipe(1.25F);
 
         TCWandAPI.regCap(new CapWrapper("iron", 0));
         TCWandAPI.regCap(new CapWrapper("copper", 1));
@@ -50,15 +50,15 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.FORBIDDEN_MAGIC.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Forbidden Magic. Applying GTNH Recipes...");
-            new WandRecipeCreator("profane").regWandRecipe(25, 5, HV).regSceptreRecipe(2F);
-            new WandRecipeCreator("tainted").regWandRecipe(175, 15, IV).regSceptreRecipe(1.4F);
-            new WandRecipeCreator("blood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.35F)
+            new WandRecipeCreator("profane").regWandRecipe(25, 5, MV).regSceptreRecipe(2F);
+            new WandRecipeCreator("tainted").regWandRecipe(175, 15, EV).regSceptreRecipe(1.4F);
+            new WandRecipeCreator("blood").regWandRecipe(115, 15, HV).regSceptreRecipe(1.35F)
                     .regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
-            new WandRecipeCreator("infernal").regWandRecipe(165, 15, IV).regSceptreRecipe(1.35F);
-            new WandRecipeCreator("livingwood").regWandRecipe(105, 15, EV).regSceptreRecipe(1.35F);
-            new WandRecipeCreator("dreamwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.3F)
+            new WandRecipeCreator("infernal").regWandRecipe(165, 15, EV).regSceptreRecipe(1.35F);
+            new WandRecipeCreator("livingwood").regWandRecipe(105, 15, HV).regSceptreRecipe(1.35F);
+            new WandRecipeCreator("dreamwood").regWandRecipe(115, 15, HV).regSceptreRecipe(1.3F)
                     .regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
-            new WandRecipeCreator("witchwood").regWandRecipe(115, 15, EV).regSceptreRecipe(1.3F)
+            new WandRecipeCreator("witchwood").regWandRecipe(115, 15, HV).regSceptreRecipe(1.3F)
                     .regUpwardStaffRecipe(150, 15).regStaffSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("manasteel", 5));
@@ -70,14 +70,14 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.THAUMIC_TINKERER.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Thaumic Tinkerer. Applying GTNH Recipes...");
-            new WandRecipeCreator("ICHORCLOTH").regWandRecipe(250, 25, UV).regSceptreRecipe(1.25F);
+            new WandRecipeCreator("ICHORCLOTH").regWandRecipe(250, 25, IV).regSceptreRecipe(1.25F);
 
             TCWandAPI.regCap(new CapWrapper("ICHOR", 8));
         }
 
         if (CompatibleMods.BLOOD_ARSENAL.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Blood Arsenal. Applying GTNH Recipes...");
-            new WandRecipeCreator("blood_wood").regWandRecipe(110, 15, EV).regSceptreRecipe(1.2F)
+            new WandRecipeCreator("blood_wood").regWandRecipe(110, 15, HV).regSceptreRecipe(1.2F)
                     .regUpwardStaffRecipe(145, 20).regStaffSceptreRecipe(1.6F);
 
             TCWandAPI.regCap(new CapWrapper("blood_iron", 6));
@@ -99,7 +99,7 @@ public class GTWandRegistry implements IWandRegistry {
                     9,
                     new ResourceLocation("taintedmagic", "textures/models/ModelWAND_CAP_CRIMSON_CLOTH.png"));
 
-            new WandRecipeCreator("warpwood").regWandRecipe(190, 15, LUV).regSceptreRecipe(1.2F)
+            new WandRecipeCreator("warpwood").regWandRecipe(190, 15, IV).regSceptreRecipe(1.2F)
                     .regUpwardStaffRecipe(220, 25).regStaffSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("cloth", 3));
@@ -110,17 +110,17 @@ public class GTWandRegistry implements IWandRegistry {
 
         if (CompatibleMods.THAUMIC_BASES.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Thaumic Bases. Applying GTNH Recipes...");
-            new WandRecipeCreator("tbthaumium").regWandRecipe(75, 10, HV).regSceptreRecipe(1.5F);
-            new WandRecipeCreator("tbvoid").regWandRecipe(175, 15, EV).regSceptreRecipe(1.2F);
+            new WandRecipeCreator("tbthaumium").regWandRecipe(75, 10, MV).regSceptreRecipe(1.5F);
+            new WandRecipeCreator("tbvoid").regWandRecipe(175, 15, HV).regSceptreRecipe(1.2F);
 
             TCWandAPI.regCap(new CapWrapper("thauminite", 6));
         }
 
         if (CompatibleMods.THAUMIC_EXPLORATION.isPresent()) {
             TCWandsMod.LOGGER.info("Detected Thaumic Exploration. Applying GTNH Recipes...");
-            new WandRecipeCreator("AMBER").regWandRecipe(20, 5, MV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15)
+            new WandRecipeCreator("AMBER").regWandRecipe(20, 5, LV).regSceptreRecipe(2F).regUpwardStaffRecipe(75, 15)
                     .regStaffSceptreRecipe(1.4F);
-            new WandRecipeCreator("TRANSMUTATION").regWandRecipe(50, 10, HV).regSceptreRecipe(1.5F)
+            new WandRecipeCreator("TRANSMUTATION").regWandRecipe(50, 10, MV).regSceptreRecipe(1.5F)
                     .regUpwardStaffRecipe(125, 15).regStaffSceptreRecipe(1.5F);
             // FIXME where's NECROMANCER
             // cores.add(new WandCore("BREAD",HV, LICH, 20, 5, 2F));//FIXME need or not need?
@@ -132,7 +132,7 @@ public class GTWandRegistry implements IWandRegistry {
         /** ChromatiCraft is non-supported content. if this ever errors out in some way feel free to remove this. */
         if (CompatibleMods.CHROMATICRAFT.isPresent()) {
             TCWandsMod.LOGGER.info("Detected ChromatiCraft. Applying GTNH Recipes...");
-            new WandRecipeCreator("CRYSTALWAND").regWandRecipe(300, 30, UV).regSceptreRecipe(2.7F);
+            new WandRecipeCreator("CRYSTALWAND").regWandRecipe(300, 30, IV).regSceptreRecipe(2.7F);
 
             TCWandAPI.regCap(new CapWrapper("TIEREDCAP_FOCAL", 10));
             TCWandAPI.regCap(new CapWrapper("TIEREDCAP_FIRAXITE", 5));

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
@@ -1,5 +1,7 @@
 package com.gtnewhorizons.tcwands.api;
 
+import static gregtech.api.util.GT_RecipeBuilder.WILDCARD;
+
 import java.util.function.Supplier;
 
 import net.minecraft.init.Items;
@@ -8,8 +10,6 @@ import net.minecraft.item.ItemStack;
 import gregtech.api.enums.Tier;
 import gregtech.api.util.GT_ModHandler;
 import thaumcraft.common.config.ConfigItems;
-
-import static gregtech.api.util.GT_RecipeBuilder.WILDCARD;
 
 public enum GTTier {
 

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
@@ -9,9 +9,11 @@ import gregtech.api.enums.Tier;
 import gregtech.api.util.GT_ModHandler;
 import thaumcraft.common.config.ConfigItems;
 
+import static gregtech.api.util.GT_RecipeBuilder.WILDCARD;
+
 public enum GTTier {
 
-    STEAM(-1, () -> new ItemStack(ConfigItems.itemResource, 1, 14)),
+    STEAM(-1, () -> new ItemStack(ConfigItems.itemShard, 1, WILDCARD)),
     LV(0, () -> GT_ModHandler.getModItem("TwilightForest", "item.nagaScale", 1, 0, new ItemStack(Items.wheat))),
     MV(1, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
     HV(2, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
@@ -13,16 +13,16 @@ import thaumcraft.common.config.ConfigItems;
 
 public enum GTTier {
 
-    STEAM(-1, () -> new ItemStack(ConfigItems.itemShard, 1, 32767)),
-    LV(0, () -> GT_ModHandler.getModItem("TwilightForest", "item.nagaScale", 1, 0, new ItemStack(Items.wheat))),
-    MV(1, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
-    HV(2, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
-    EV(3, () -> GT_ModHandler.getModItem("TwilightForest", "item.fieryBlood", 1, 0, new ItemStack(Items.potato))),
-    IV(4, () -> GT_ModHandler
+    STEAM(0, () -> new ItemStack(ConfigItems.itemShard, 1, 32767)),
+    LV(1, () -> GT_ModHandler.getModItem("TwilightForest", "item.nagaScale", 1, 0, new ItemStack(Items.wheat))),
+    MV(2, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
+    HV(3, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
+    EV(4, () -> GT_ModHandler.getModItem("TwilightForest", "item.fieryBlood", 1, 0, new ItemStack(Items.potato))),
+    IV(5, () -> GT_ModHandler
             .getModItem("TwilightForest", "item.fieryTears", 1, 0, new ItemStack(Items.poisonous_potato))),
-    LUV(5, () -> GT_ModHandler.getModItem("TwilightForest", "item.carminite", 1, 0, new ItemStack(Items.apple))),
-    ZPM(6, () -> GT_ModHandler.getModItem("TwilightForest", "item.carminite", 1, 0, new ItemStack(Items.apple))),
-    UV(7, () -> GT_ModHandler.getModItem("dreamcraft", "item.SnowQueenBlood", 1, 0, new ItemStack(Items.cake)));
+    LUV(6, () -> GT_ModHandler.getModItem("TwilightForest", "item.carminite", 1, 0, new ItemStack(Items.apple))),
+    ZPM(7, () -> GT_ModHandler.getModItem("TwilightForest", "item.carminite", 1, 0, new ItemStack(Items.apple))),
+    UV(8, () -> GT_ModHandler.getModItem("dreamcraft", "item.SnowQueenBlood", 1, 0, new ItemStack(Items.cake)));
 
     private static final GTTier[] tiers;
 

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
@@ -7,9 +7,11 @@ import net.minecraft.item.ItemStack;
 
 import gregtech.api.enums.Tier;
 import gregtech.api.util.GT_ModHandler;
+import thaumcraft.common.config.ConfigItems;
 
 public enum GTTier {
 
+    STEAM(-1, () -> new ItemStack(ConfigItems.itemResource, 1, 14)),
     LV(0, () -> GT_ModHandler.getModItem("TwilightForest", "item.nagaScale", 1, 0, new ItemStack(Items.wheat))),
     MV(1, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
     HV(2, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
@@ -13,7 +13,7 @@ import static gregtech.api.util.GT_RecipeBuilder.WILDCARD;
 
 public enum GTTier {
 
-    STEAM(-1, () -> new ItemStack(ConfigItems.itemShard, 1, WILDCARD)),
+    STEAM(-1, () -> new ItemStack(ConfigItems.itemShard, 1, 32767)),
     LV(0, () -> GT_ModHandler.getModItem("TwilightForest", "item.nagaScale", 1, 0, new ItemStack(Items.wheat))),
     MV(1, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),
     HV(2, () -> GT_ModHandler.getModItem("dreamcraft", "item.LichBone", 1, 0, new ItemStack(Items.carrot))),

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTTier.java
@@ -1,7 +1,5 @@
 package com.gtnewhorizons.tcwands.api;
 
-import static gregtech.api.util.GT_RecipeBuilder.WILDCARD;
-
 import java.util.function.Supplier;
 
 import net.minecraft.init.Items;


### PR DESCRIPTION
As stated in the title, and as has been discussed in #Meta-Dev before a year or so ago, this PR focuses on rebalancing thaum to start in steam, because as has been said before, Thaumcraft functions best as early-game as possible, because unlike GT, it doesn't have an exact linear progress, and a lot of its content starts to taper off after HV, which is super unfortunate given its current tiering.

The biggest thing this does, in combination with its sister pr ([link](https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/925)) is to rebalance the wands, alongside certain other recipe tweaks here and there.

Every wand is tiered down a bit, including the Ichor to IV, being the last wand, I might push it to LUV though, and the starting wand uses any normal thaumcraft shard, I was originally going to do salis, but then I started to realize "you can't exactly make a crucible without a wand" though I may add a decently difficult steam age recipe for salis, later and revert back to this.

You may ask yourself, "Alastor, but how are they going to get the shards for everything?"
There's two solutions to this:
1. We could add shards to the OW small ore generation like silver
2. There's already multiple villagers that outright sell shards