### PR TITLE
Keep this data for use by other mods

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.309:dev')
-    api('com.github.GTNewHorizons:twilightforest:2.7.7:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.382:dev')
+    api('com.github.GTNewHorizons:twilightforest:2.7.8:dev')
 
     api('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly('org.jetbrains:annotations:23.0.0')
@@ -11,11 +11,11 @@ dependencies {
     runtimeOnly('curse.maven:thaumcraft-nei-plugin-225095:2241913')
 
 //    devOnlyNonPublishable('com.github.GTNewHorizons:ForbiddenMagic:0.8.0-GTNH:dev')
-//    devOnlyNonPublishable('com.github.GTNewHorizons:ThaumicTinkerer:2.11.12:dev')
-//    devOnlyNonPublishable('com.github.GTNewHorizons:BloodArsenal:1.4.3:dev')
+//    devOnlyNonPublishable('com.github.GTNewHorizons:ThaumicTinkerer:2.11.15:dev')
+//    devOnlyNonPublishable('com.github.GTNewHorizons:BloodArsenal:1.4.6:dev')
 //    devOnlyNonPublishable('com.github.GTNewHorizons:Tainted-Magic:7.6.19-GTNH:dev')
-//    devOnlyNonPublishable('com.github.GTNewHorizons:ThaumicBases:1.8.8:dev')
-//    devOnlyNonPublishable('com.github.GTNewHorizons:Thaumic_Exploration:1.4.0-GTNH:dev')
+//    devOnlyNonPublishable('com.github.GTNewHorizons:ThaumicBases:1.8.11:dev')
+//    devOnlyNonPublishable('com.github.GTNewHorizons:Thaumic_Exploration:1.4.2-GTNH:dev')
 
     // Replace Baubles
     project.getConfigurations()
@@ -23,7 +23,7 @@ dependencies {
                 final DependencySubstitutions ds = c.getResolutionStrategy()
                         .getDependencySubstitution()
                 ds.substitute(ds.module("com.github.GTNewHorizons:Baubles"))
-                        .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.1.8-GTNH"))
+                        .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH"))
                         .withClassifier("dev")
                         .because("Baubles-Expanded replaces Baubles")
             })

--- a/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
@@ -23,9 +23,9 @@ import thaumcraft.common.lib.crafting.ArcaneWandRecipe;
 public class TCWandAPI {
 
     private static ArrayList<Object> craftingRecipes;
-    private static ArrayList<IWandRegistry> registries = new ArrayList<>();
-    private static ArrayList<AbstractWandWrapper> wandWrappers = new ArrayList<>();
-    private static ArrayList<CapWrapper> caps = new ArrayList<>();
+    private static final ArrayList<IWandRegistry> registries = new ArrayList<>();
+    private static final ArrayList<AbstractWandWrapper> wandWrappers = new ArrayList<>();
+    private static final ArrayList<CapWrapper> caps = new ArrayList<>();
 
     static {
         try {
@@ -54,7 +54,6 @@ public class TCWandAPI {
         }
 
         makeWands();
-        dispose();
     }
 
     /**
@@ -148,11 +147,5 @@ public class TCWandAPI {
 
     private static void removeTCWands() {
         craftingRecipes.removeIf(r -> r instanceof ArcaneWandRecipe || r instanceof ArcaneSceptreRecipe);
-    }
-
-    private static void dispose() {
-        registries = null;
-        wandWrappers = null;
-        caps = null;
     }
 }


### PR DESCRIPTION
Keeping this data seems like the best way to let Salis Arcana get the right screw, conductor, and cost for its wand part replacement feature. Its memory impact looks small; there are 80 `wandWrappers` and 20 `caps` with all of the parts added by the dependencies.