### PR TITLE
Refactor Wand Recipe Creation

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,6 +6,7 @@ dependencies {
 
     api('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') {transitive = false}
     compileOnly('org.jetbrains:annotations:23.0.0')
+    compileOnly("com.github.GTNewHorizons:Salis-Arcana:1.1.49-GTNH:dev")
 
     runtimeOnly('com.github.GTNewHorizons:AspectRecipeIndex:1.0.11:dev')
     runtimeOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH:dev')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,8 +8,8 @@ dependencies {
     compileOnly('org.jetbrains:annotations:23.0.0')
     compileOnly("com.github.GTNewHorizons:Salis-Arcana:1.1.49-GTNH:dev")
 
-    runtimeOnly('com.github.GTNewHorizons:AspectRecipeIndex:1.0.11:dev')
-    runtimeOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:AspectRecipeIndex:1.0.11:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH:dev')
 
 //    devOnlyNonPublishable('com.github.GTNewHorizons:ForbiddenMagic:0.9.14-GTNH:dev')
 //    devOnlyNonPublishable('com.github.GTNewHorizons:ThaumicTinkerer:2.12.19:dev')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.398:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.52.480:dev')
     api('com.github.GTNewHorizons:twilightforest:2.7.26:dev')
 
     api('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev') {transitive = false}

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ developmentEnvironmentUserName = Developer
 # - jabel: Jabel syntax-only support, compiles to J8 bytecode
 # - jvmDowngrader: Full modern Java via JVM Downgrader (syntax + stdlib APIs)
 # - modern: Native modern Java bytecode, no downgrading
-enableModernJavaSyntax = false
+enableModernJavaSyntax = jabel
 
 # If set, ignores the above setting and compiles with the given toolchain. This may cause unexpected issues,
 # and should *not* be used in most situations. -1 disables this.

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTNHScepterRecipe.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTNHScepterRecipe.java
@@ -1,0 +1,90 @@
+package com.gtnewhorizons.tcwands.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+
+import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.SceptreWrapper;
+
+import thaumcraft.common.config.ConfigItems;
+import thaumcraft.common.lib.research.ResearchManager;
+
+public class GTNHScepterRecipe extends GTNHWandRecipe {
+
+    private static final int[] SLOT_CAP = new int[] { 1, 5, 6 };
+    private static final int[] SLOT_SCREW = new int[] { 3, 7 };
+    private static final int SLOT_CHARM = 2;
+    private static final ItemStack CHARM = new ItemStack(ConfigItems.itemResource, 1, 15);
+
+    @Override
+    public boolean matches(IInventory craftingTable, World world, EntityPlayer player) {
+        return super.matches(craftingTable, world, player) && checkPrimalCharm(craftingTable);
+    }
+
+    @Override
+    public ItemStack getCraftingResult(IInventory craftingTable) {
+        AbstractWandWrapper wandWrapper = getWandWrapper(craftingTable.getStackInSlot(SLOT_CORE));
+        CapWrapper capWrapper = getCapWrapper(craftingTable);
+        if (wandWrapper == null || capWrapper == null) return null;
+        return wandWrapper.getItem(capWrapper);
+    }
+
+    private static boolean checkPrimalCharm(IInventory craftingTable) {
+        return OreDictionary.itemMatches(craftingTable.getStackInSlot(SLOT_CHARM), CHARM, true);
+    }
+
+    @Override
+    protected CapWrapper getCapWrapper(IInventory craftingTable) {
+        ItemStack cap = craftingTable.getStackInSlot(SLOT_CAP[0]);
+        for (CapWrapper wrapper : TCWandAPI.getCaps()) {
+            if (OreDictionary.itemMatches(cap, wrapper.getItem(), true)) {
+                return wrapper;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected int[] screwSlots() {
+        return SLOT_SCREW;
+    }
+
+    @Override
+    protected AbstractWandWrapper getWandWrapper(ItemStack rodItem) {
+        for (AbstractWandWrapper wrapper : TCWandAPI.getWandWrappers()) {
+            if (!(wrapper instanceof SceptreWrapper)) continue;
+            if (OreDictionary.itemMatches(rodItem, wrapper.getCraftingRod(), true)) {
+                return wrapper;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean checkCaps(IInventory craftingTable, EntityPlayer player) {
+        ItemStack cap = craftingTable.getStackInSlot(SLOT_CAP[0]);
+        CapWrapper capWrapper = getCapWrapper(craftingTable);
+        return cap != null && capWrapper != null
+                && ResearchManager.isResearchComplete(player.getCommandSenderName(), capWrapper.getResearch())
+                && OreDictionary.itemMatches(cap, craftingTable.getStackInSlot(SLOT_CAP[1]), true)
+                && OreDictionary.itemMatches(cap, craftingTable.getStackInSlot(SLOT_CAP[2]), true);
+    }
+
+    @Override
+    public String getResearch() {
+        return "SCEPTRE";
+    }
+
+    @Override
+    public String[] salisArcana$getResearches(IInventory inv, World world, EntityPlayer player) {
+        String[] strings = new String[3];
+        strings[0] = getWandWrapper(inv.getStackInSlot(SLOT_CORE)).getResearchName();
+        strings[1] = getCapWrapper(inv).getResearch();
+        strings[2] = "SCEPTRE";
+        return strings;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTNHScepterRecipe.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTNHScepterRecipe.java
@@ -8,44 +8,37 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
 import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
-import com.gtnewhorizons.tcwands.api.wrappers.SceptreWrapper;
 
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.lib.research.ResearchManager;
 
 public class GTNHScepterRecipe extends GTNHWandRecipe {
 
-    private static final int[] SLOT_CAP = new int[] { 1, 5, 6 };
+    private static final int[] SLOT_CAP = new int[] { 6, 5, 1 };
     private static final int[] SLOT_SCREW = new int[] { 3, 7 };
     private static final int SLOT_CHARM = 2;
     private static final ItemStack CHARM = new ItemStack(ConfigItems.itemResource, 1, 15);
 
     @Override
-    public boolean matches(IInventory craftingTable, World world, EntityPlayer player) {
-        return super.matches(craftingTable, world, player) && checkPrimalCharm(craftingTable);
+    public boolean matches(IInventory inv, World world, EntityPlayer player) {
+        return super.matches(inv, world, player) && checkPrimalCharm(inv);
     }
 
     @Override
-    public ItemStack getCraftingResult(IInventory craftingTable) {
-        AbstractWandWrapper wandWrapper = getWandWrapper(craftingTable.getStackInSlot(SLOT_CORE));
-        CapWrapper capWrapper = getCapWrapper(craftingTable);
+    public ItemStack getCraftingResult(IInventory inv) {
+        AbstractWandWrapper wandWrapper = getWandWrapper(inv.getStackInSlot(SLOT_CORE));
+        CapWrapper capWrapper = TCWandAPI.getWrapperForCap(inv.getStackInSlot(SLOT_CAP[0]));
         if (wandWrapper == null || capWrapper == null) return null;
         return wandWrapper.getItem(capWrapper);
     }
 
-    private static boolean checkPrimalCharm(IInventory craftingTable) {
-        return OreDictionary.itemMatches(craftingTable.getStackInSlot(SLOT_CHARM), CHARM, true);
+    @Override
+    protected AbstractWandWrapper getWandWrapper(ItemStack rod) {
+        return TCWandAPI.getWrapperForRod(rod, true);
     }
 
-    @Override
-    protected CapWrapper getCapWrapper(IInventory craftingTable) {
-        ItemStack cap = craftingTable.getStackInSlot(SLOT_CAP[0]);
-        for (CapWrapper wrapper : TCWandAPI.getCaps()) {
-            if (OreDictionary.itemMatches(cap, wrapper.getItem(), true)) {
-                return wrapper;
-            }
-        }
-        return null;
+    private static boolean checkPrimalCharm(IInventory inv) {
+        return OreDictionary.itemMatches(inv.getStackInSlot(SLOT_CHARM), CHARM, true);
     }
 
     @Override
@@ -54,24 +47,13 @@ public class GTNHScepterRecipe extends GTNHWandRecipe {
     }
 
     @Override
-    protected AbstractWandWrapper getWandWrapper(ItemStack rodItem) {
-        for (AbstractWandWrapper wrapper : TCWandAPI.getWandWrappers()) {
-            if (!(wrapper instanceof SceptreWrapper)) continue;
-            if (OreDictionary.itemMatches(rodItem, wrapper.getCraftingRod(), true)) {
-                return wrapper;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    protected boolean checkCaps(IInventory craftingTable, EntityPlayer player) {
-        ItemStack cap = craftingTable.getStackInSlot(SLOT_CAP[0]);
-        CapWrapper capWrapper = getCapWrapper(craftingTable);
+    protected boolean checkCaps(IInventory inv, EntityPlayer player) {
+        ItemStack cap = inv.getStackInSlot(SLOT_CAP[0]);
+        CapWrapper capWrapper = TCWandAPI.getWrapperForCap(inv.getStackInSlot(SLOT_CAP[0]));
         return cap != null && capWrapper != null
                 && ResearchManager.isResearchComplete(player.getCommandSenderName(), capWrapper.getResearch())
-                && OreDictionary.itemMatches(cap, craftingTable.getStackInSlot(SLOT_CAP[1]), true)
-                && OreDictionary.itemMatches(cap, craftingTable.getStackInSlot(SLOT_CAP[2]), true);
+                && OreDictionary.itemMatches(cap, inv.getStackInSlot(SLOT_CAP[1]), true)
+                && OreDictionary.itemMatches(cap, inv.getStackInSlot(SLOT_CAP[2]), true);
     }
 
     @Override
@@ -82,8 +64,10 @@ public class GTNHScepterRecipe extends GTNHWandRecipe {
     @Override
     public String[] salisArcana$getResearches(IInventory inv, World world, EntityPlayer player) {
         String[] strings = new String[3];
-        strings[0] = getWandWrapper(inv.getStackInSlot(SLOT_CORE)).getResearchName();
-        strings[1] = getCapWrapper(inv).getResearch();
+        AbstractWandWrapper rod = TCWandAPI.getWrapperForRod(inv.getStackInSlot(SLOT_CORE), true);
+        if (rod != null) strings[0] = rod.getResearchName();
+        CapWrapper cap = TCWandAPI.getWrapperForCap(inv.getStackInSlot(SLOT_CAP[0]));
+        if (cap != null) strings[1] = cap.getResearch();
         strings[2] = "SCEPTRE";
         return strings;
     }

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTNHWandRecipe.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTNHWandRecipe.java
@@ -1,0 +1,144 @@
+package com.gtnewhorizons.tcwands.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+
+import com.gtnewhorizons.tcwands.api.wandinfo.WandDetails;
+import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.SceptreWrapper;
+
+import cpw.mods.fml.common.Optional;
+import dev.rndmorris.salisarcana.api.IMultipleResearchArcaneRecipe;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.common.lib.research.ResearchManager;
+
+@Optional.Interface(iface = "dev.rndmorris.salisarcana.api.IMultipleResearchArcaneRecipe", modid = "salisarcana")
+public class GTNHWandRecipe implements IArcaneRecipe, IMultipleResearchArcaneRecipe {
+
+    private static final int[] SLOT_CAP = new int[] { 2, 6 };
+    private static final int[] SLOT_SCREW = new int[] { 1, 3, 5, 7 };
+    private static final int[] SLOT_CONDUCTOR = new int[] { 0, 8 };
+    protected static final int SLOT_CORE = 4;
+
+    @Override
+    public boolean matches(IInventory craftingTable, World world, EntityPlayer player) {
+        final ItemStack rodItem = craftingTable.getStackInSlot(SLOT_CORE);
+        if (rodItem == null) return false;
+        AbstractWandWrapper wrapper = getWandWrapper(rodItem);
+        if (wrapper == null
+                || !ResearchManager.isResearchComplete(player.getCommandSenderName(), wrapper.getResearchName()))
+            return false;
+        WandDetails details = wrapper.getDetails();
+        if (!checkScrews(craftingTable, details)) return false;
+        ItemStack conductor = details.getConductor();
+        for (int slot : SLOT_CONDUCTOR) {
+            if (!OreDictionary.itemMatches(craftingTable.getStackInSlot(slot), conductor, true)) return false;
+        }
+
+        return checkCaps(craftingTable, player);
+    }
+
+    private boolean checkScrews(IInventory craftingTable, WandDetails details) {
+        int screwOredict = OreDictionary.getOreID(details.getScrew());
+        for (int slot : screwSlots()) {
+            final ItemStack s = craftingTable.getStackInSlot(slot);
+            if (s == null || !hasOredict(s, screwOredict)) return false;
+        }
+        return true;
+    }
+
+    protected int[] screwSlots() {
+        return SLOT_SCREW;
+    }
+
+    protected AbstractWandWrapper getWandWrapper(ItemStack rodItem) {
+        for (AbstractWandWrapper wrapper : TCWandAPI.getWandWrappers()) {
+            if (wrapper instanceof SceptreWrapper) continue;
+            if (OreDictionary.itemMatches(rodItem, wrapper.getCraftingRod(), true)) {
+                return wrapper;
+            }
+        }
+        return null;
+    }
+
+    protected CapWrapper getCapWrapper(IInventory craftingTable) {
+        ItemStack cap = craftingTable.getStackInSlot(SLOT_CAP[0]);
+        for (CapWrapper wrapper : TCWandAPI.getCaps()) {
+            if (OreDictionary.itemMatches(cap, wrapper.getItem(), true)) {
+                return wrapper;
+            }
+        }
+        return null;
+    }
+
+    protected boolean checkCaps(IInventory craftingTable, EntityPlayer player) {
+        ItemStack cap = craftingTable.getStackInSlot(SLOT_CAP[0]);
+        CapWrapper capWrapper = getCapWrapper(craftingTable);
+        return cap != null && capWrapper != null
+                && ResearchManager.isResearchComplete(player.getCommandSenderName(), capWrapper.getResearch())
+                && OreDictionary.itemMatches(cap, craftingTable.getStackInSlot(SLOT_CAP[1]), true);
+    }
+
+    private boolean hasOredict(ItemStack s, int screw) {
+        int[] oreIDs = OreDictionary.getOreIDs(s);
+        for (int ore : oreIDs) {
+            if (ore == screw) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public ItemStack getCraftingResult(IInventory craftingTable) {
+        AbstractWandWrapper wandWrapper = getWandWrapper(craftingTable.getStackInSlot(SLOT_CORE));
+        CapWrapper capWrapper = getCapWrapper(craftingTable);
+        if (wandWrapper == null || capWrapper == null) return null;
+        return wandWrapper.getItem(capWrapper);
+    }
+
+    @Override
+    public int getRecipeSize() {
+        return 9;
+    }
+
+    @Override
+    public AspectList getAspects(IInventory craftingTable) {
+        AbstractWandWrapper wandWrapper = getWandWrapper(craftingTable.getStackInSlot(SLOT_CORE));
+        CapWrapper capWrapper = getCapWrapper(craftingTable);
+        if (wandWrapper == null || capWrapper == null) return new AspectList();
+        int recipeCost = wandWrapper.getRecipeCost(capWrapper);
+        AspectList cost = new AspectList();
+        for (Aspect a : Aspect.getPrimalAspects()) {
+            cost.add(a, recipeCost);
+        }
+        return cost;
+    }
+
+    @Override
+    public ItemStack getRecipeOutput() {
+        return null;
+    }
+
+    @Override
+    public AspectList getAspects() {
+        return null;
+    }
+
+    @Override
+    public String getResearch() {
+        return "";
+    }
+
+    @Override
+    public String[] salisArcana$getResearches(IInventory inv, World world, EntityPlayer player) {
+        String[] strings = new String[2];
+        strings[0] = getWandWrapper(inv.getStackInSlot(SLOT_CORE)).getResearchName();
+        strings[1] = getCapWrapper(inv).getResearch();
+        return strings;
+    }
+}

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTNHWandRecipe.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTNHWandRecipe.java
@@ -9,7 +9,6 @@ import net.minecraftforge.oredict.OreDictionary;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandDetails;
 import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
 import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
-import com.gtnewhorizons.tcwands.api.wrappers.SceptreWrapper;
 
 import cpw.mods.fml.common.Optional;
 import dev.rndmorris.salisarcana.api.IMultipleResearchArcaneRecipe;
@@ -21,33 +20,33 @@ import thaumcraft.common.lib.research.ResearchManager;
 @Optional.Interface(iface = "dev.rndmorris.salisarcana.api.IMultipleResearchArcaneRecipe", modid = "salisarcana")
 public class GTNHWandRecipe implements IArcaneRecipe, IMultipleResearchArcaneRecipe {
 
-    private static final int[] SLOT_CAP = new int[] { 2, 6 };
+    private static final int[] SLOT_CAP = new int[] { 6, 2 };
     private static final int[] SLOT_SCREW = new int[] { 1, 3, 5, 7 };
     private static final int[] SLOT_CONDUCTOR = new int[] { 0, 8 };
     protected static final int SLOT_CORE = 4;
 
     @Override
-    public boolean matches(IInventory craftingTable, World world, EntityPlayer player) {
-        final ItemStack rodItem = craftingTable.getStackInSlot(SLOT_CORE);
+    public boolean matches(IInventory inv, World world, EntityPlayer player) {
+        final ItemStack rodItem = inv.getStackInSlot(SLOT_CORE);
         if (rodItem == null) return false;
-        AbstractWandWrapper wrapper = getWandWrapper(rodItem);
+        AbstractWandWrapper wrapper = TCWandAPI.getWrapperForRod(rodItem, false);
         if (wrapper == null
                 || !ResearchManager.isResearchComplete(player.getCommandSenderName(), wrapper.getResearchName()))
             return false;
         WandDetails details = wrapper.getDetails();
-        if (!checkScrews(craftingTable, details)) return false;
+        if (!checkScrews(inv, details)) return false;
         ItemStack conductor = details.getConductor();
         for (int slot : SLOT_CONDUCTOR) {
-            if (!OreDictionary.itemMatches(craftingTable.getStackInSlot(slot), conductor, true)) return false;
+            if (!OreDictionary.itemMatches(inv.getStackInSlot(slot), conductor, true)) return false;
         }
 
-        return checkCaps(craftingTable, player);
+        return checkCaps(inv, player);
     }
 
-    private boolean checkScrews(IInventory craftingTable, WandDetails details) {
+    private boolean checkScrews(IInventory inv, WandDetails details) {
         int screwOredict = OreDictionary.getOreID(details.getScrew());
         for (int slot : screwSlots()) {
-            final ItemStack s = craftingTable.getStackInSlot(slot);
+            final ItemStack s = inv.getStackInSlot(slot);
             if (s == null || !hasOredict(s, screwOredict)) return false;
         }
         return true;
@@ -57,32 +56,12 @@ public class GTNHWandRecipe implements IArcaneRecipe, IMultipleResearchArcaneRec
         return SLOT_SCREW;
     }
 
-    protected AbstractWandWrapper getWandWrapper(ItemStack rodItem) {
-        for (AbstractWandWrapper wrapper : TCWandAPI.getWandWrappers()) {
-            if (wrapper instanceof SceptreWrapper) continue;
-            if (OreDictionary.itemMatches(rodItem, wrapper.getCraftingRod(), true)) {
-                return wrapper;
-            }
-        }
-        return null;
-    }
-
-    protected CapWrapper getCapWrapper(IInventory craftingTable) {
-        ItemStack cap = craftingTable.getStackInSlot(SLOT_CAP[0]);
-        for (CapWrapper wrapper : TCWandAPI.getCaps()) {
-            if (OreDictionary.itemMatches(cap, wrapper.getItem(), true)) {
-                return wrapper;
-            }
-        }
-        return null;
-    }
-
-    protected boolean checkCaps(IInventory craftingTable, EntityPlayer player) {
-        ItemStack cap = craftingTable.getStackInSlot(SLOT_CAP[0]);
-        CapWrapper capWrapper = getCapWrapper(craftingTable);
+    protected boolean checkCaps(IInventory inv, EntityPlayer player) {
+        ItemStack cap = inv.getStackInSlot(SLOT_CAP[0]);
+        CapWrapper capWrapper = TCWandAPI.getWrapperForCap(inv.getStackInSlot(SLOT_CAP[0]));
         return cap != null && capWrapper != null
                 && ResearchManager.isResearchComplete(player.getCommandSenderName(), capWrapper.getResearch())
-                && OreDictionary.itemMatches(cap, craftingTable.getStackInSlot(SLOT_CAP[1]), true);
+                && OreDictionary.itemMatches(cap, inv.getStackInSlot(SLOT_CAP[1]), true);
     }
 
     private boolean hasOredict(ItemStack s, int screw) {
@@ -94,9 +73,9 @@ public class GTNHWandRecipe implements IArcaneRecipe, IMultipleResearchArcaneRec
     }
 
     @Override
-    public ItemStack getCraftingResult(IInventory craftingTable) {
-        AbstractWandWrapper wandWrapper = getWandWrapper(craftingTable.getStackInSlot(SLOT_CORE));
-        CapWrapper capWrapper = getCapWrapper(craftingTable);
+    public ItemStack getCraftingResult(IInventory inv) {
+        AbstractWandWrapper wandWrapper = getWandWrapper(inv.getStackInSlot(SLOT_CORE));
+        CapWrapper capWrapper = TCWandAPI.getWrapperForCap(inv.getStackInSlot(SLOT_CAP[0]));
         if (wandWrapper == null || capWrapper == null) return null;
         return wandWrapper.getItem(capWrapper);
     }
@@ -107,9 +86,9 @@ public class GTNHWandRecipe implements IArcaneRecipe, IMultipleResearchArcaneRec
     }
 
     @Override
-    public AspectList getAspects(IInventory craftingTable) {
-        AbstractWandWrapper wandWrapper = getWandWrapper(craftingTable.getStackInSlot(SLOT_CORE));
-        CapWrapper capWrapper = getCapWrapper(craftingTable);
+    public AspectList getAspects(IInventory inv) {
+        AbstractWandWrapper wandWrapper = getWandWrapper(inv.getStackInSlot(SLOT_CORE));
+        CapWrapper capWrapper = TCWandAPI.getWrapperForCap(inv.getStackInSlot(SLOT_CAP[0]));
         if (wandWrapper == null || capWrapper == null) return new AspectList();
         int recipeCost = wandWrapper.getRecipeCost(capWrapper);
         AspectList cost = new AspectList();
@@ -117,6 +96,10 @@ public class GTNHWandRecipe implements IArcaneRecipe, IMultipleResearchArcaneRec
             cost.add(a, recipeCost);
         }
         return cost;
+    }
+
+    protected AbstractWandWrapper getWandWrapper(ItemStack rod) {
+        return TCWandAPI.getWrapperForRod(rod, false);
     }
 
     @Override
@@ -137,8 +120,10 @@ public class GTNHWandRecipe implements IArcaneRecipe, IMultipleResearchArcaneRec
     @Override
     public String[] salisArcana$getResearches(IInventory inv, World world, EntityPlayer player) {
         String[] strings = new String[2];
-        strings[0] = getWandWrapper(inv.getStackInSlot(SLOT_CORE)).getResearchName();
-        strings[1] = getCapWrapper(inv).getResearch();
+        AbstractWandWrapper rod = getWandWrapper(inv.getStackInSlot(SLOT_CORE));
+        if (rod != null) strings[0] = rod.getResearchName();
+        CapWrapper cap = TCWandAPI.getWrapperForCap(inv.getStackInSlot(SLOT_CAP[0]));
+        if (cap != null) strings[1] = cap.getResearch();
         return strings;
     }
 }

--- a/src/main/java/com/gtnewhorizons/tcwands/api/GTNHWandRecipe.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/GTNHWandRecipe.java
@@ -35,7 +35,7 @@ public class GTNHWandRecipe implements IArcaneRecipe, IMultipleResearchArcaneRec
             return false;
         WandDetails details = wrapper.getDetails();
         if (!checkScrews(inv, details)) return false;
-        ItemStack conductor = details.getConductor();
+        ItemStack conductor = details.conductor();
         for (int slot : SLOT_CONDUCTOR) {
             if (!OreDictionary.itemMatches(inv.getStackInSlot(slot), conductor, true)) return false;
         }

--- a/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
@@ -1,12 +1,15 @@
 package com.gtnewhorizons.tcwands.api;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.oredict.OreDictionary;
 
+import com.github.bsideup.jabel.Desugar;
 import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
 import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
 import com.gtnewhorizons.tcwands.api.wrappers.SceptreWrapper;
@@ -24,7 +27,9 @@ public class TCWandAPI {
 
     private static final ArrayList<IWandRegistry> registries = new ArrayList<>();
     private static final ArrayList<AbstractWandWrapper> wandWrappers = new ArrayList<>();
+    private static final Map<String, Map<Boolean, AbstractWandWrapper>> rodTagToWrapper = new HashMap<>();
     private static final ArrayList<CapWrapper> caps = new ArrayList<>();
+    private static final HashMap<String, CapWrapper> capTagToWrapper = new HashMap<>();
 
     /**
      * Call it during {@link cpw.mods.fml.common.event.FMLInitializationEvent}
@@ -50,6 +55,9 @@ public class TCWandAPI {
      */
     public static void regWandWrapper(AbstractWandWrapper wandWrapper) {
         wandWrappers.add(wandWrapper);
+        rodTagToWrapper
+                .computeIfAbsent(wandWrapper.getRodName(), k -> new HashMap<>())
+                .put(wandWrapper instanceof SceptreWrapper, wandWrapper);
     }
 
     /**
@@ -57,6 +65,7 @@ public class TCWandAPI {
      */
     public static void regCap(CapWrapper cap) {
         caps.add(cap);
+        capTagToWrapper.put(cap.getName(), cap);
     }
 
     @SuppressWarnings("unchecked")
@@ -136,27 +145,36 @@ public class TCWandAPI {
         return wandWrappers;
     }
 
-    public static CapWrapper getWrapperForCap(ItemStack cap) {
-        for (CapWrapper wrapper : caps) {
-            if (OreDictionary.itemMatches(wrapper.getItem(), cap, true)) return wrapper;
-        }
-        return null;
+    public static AbstractWandWrapper getWrapperForRod(String tag, boolean scepter) {
+        Map<Boolean, AbstractWandWrapper> inner = rodTagToWrapper.get(tag);
+        return inner != null ? inner.get(scepter) : null;
     }
 
-    public static CapWrapper getWrapperForCap(WandCap cap) {
-        return getWrapperForCap(cap.getItem());
-    }
-
-    public static AbstractWandWrapper getWrapperForRod(ItemStack rod, boolean scepter) {
-        for (AbstractWandWrapper wrapper : wandWrappers) {
-            if ((wrapper instanceof SceptreWrapper == scepter)
-                    && OreDictionary.itemMatches(wrapper.getCraftingRod(), rod, true))
-                return wrapper;
+    public static AbstractWandWrapper getWrapperForRod(ItemStack item, boolean scepter) {
+        for (WandRod rod : WandRod.rods.values()) {
+            if (OreDictionary.itemMatches(rod.getItem(), item, true)) {
+                return getWrapperForRod(rod, scepter);
+            }
         }
         return null;
     }
 
     public static AbstractWandWrapper getWrapperForRod(WandRod rod, boolean scepter) {
-        return getWrapperForRod(rod.getItem(), scepter);
+        return getWrapperForRod(rod.getTag(), scepter);
+    }
+
+    public static CapWrapper getWrapperForCap(String tag) {
+        return capTagToWrapper.get(tag);
+    }
+
+    public static CapWrapper getWrapperForCap(ItemStack item) {
+        for (WandCap cap : WandCap.caps.values()) {
+            if (OreDictionary.itemMatches(cap.getItem(), item, true)) return getWrapperForCap(cap);
+        }
+        return null;
+    }
+
+    public static CapWrapper getWrapperForCap(WandCap cap) {
+        return getWrapperForCap(cap.getTag());
     }
 }

--- a/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
@@ -5,9 +5,11 @@ import java.util.List;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.oredict.OreDictionary;
 
 import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
 import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.SceptreWrapper;
 
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
@@ -132,5 +134,29 @@ public class TCWandAPI {
 
     public static ArrayList<AbstractWandWrapper> getWandWrappers() {
         return wandWrappers;
+    }
+
+    public static CapWrapper getWrapperForCap(ItemStack cap) {
+        for (CapWrapper wrapper : caps) {
+            if (OreDictionary.itemMatches(wrapper.getItem(), cap, true)) return wrapper;
+        }
+        return null;
+    }
+
+    public static CapWrapper getWrapperForCap(WandCap cap) {
+        return getWrapperForCap(cap.getItem());
+    }
+
+    public static AbstractWandWrapper getWrapperForRod(ItemStack rod, boolean scepter) {
+        for (AbstractWandWrapper wrapper : wandWrappers) {
+            if ((wrapper instanceof SceptreWrapper == scepter)
+                    && OreDictionary.itemMatches(wrapper.getCraftingRod(), rod, true))
+                return wrapper;
+        }
+        return null;
+    }
+
+    public static AbstractWandWrapper getWrapperForRod(WandRod rod, boolean scepter) {
+        return getWrapperForRod(rod.getItem(), scepter);
     }
 }

--- a/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
@@ -1,6 +1,5 @@
 package com.gtnewhorizons.tcwands.api;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,20 +21,9 @@ import thaumcraft.common.lib.crafting.ArcaneWandRecipe;
 
 public class TCWandAPI {
 
-    private static ArrayList<Object> craftingRecipes;
     private static final ArrayList<IWandRegistry> registries = new ArrayList<>();
     private static final ArrayList<AbstractWandWrapper> wandWrappers = new ArrayList<>();
     private static final ArrayList<CapWrapper> caps = new ArrayList<>();
-
-    static {
-        try {
-            Field f = ThaumcraftApi.class.getDeclaredField("craftingRecipes");
-            f.setAccessible(true);
-            craftingRecipes = (ArrayList<Object>) f.get(null);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            e.printStackTrace();
-        }
-    }
 
     /**
      * Call it during {@link cpw.mods.fml.common.event.FMLInitializationEvent}
@@ -145,8 +133,10 @@ public class TCWandAPI {
         cap.setTexture(texture);
     }
 
+    @SuppressWarnings("unchecked")
     private static void removeTCWands() {
-        craftingRecipes.removeIf(r -> r instanceof ArcaneWandRecipe || r instanceof ArcaneSceptreRecipe);
+        ThaumcraftApi.getCraftingRecipes()
+                .removeIf(r -> r instanceof ArcaneWandRecipe || r instanceof ArcaneSceptreRecipe);
     }
 
     public static ArrayList<CapWrapper> getCaps() {

--- a/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
@@ -9,7 +9,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.oredict.OreDictionary;
 
-import com.github.bsideup.jabel.Desugar;
 import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
 import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
 import com.gtnewhorizons.tcwands.api.wrappers.SceptreWrapper;
@@ -55,8 +54,7 @@ public class TCWandAPI {
      */
     public static void regWandWrapper(AbstractWandWrapper wandWrapper) {
         wandWrappers.add(wandWrapper);
-        rodTagToWrapper
-                .computeIfAbsent(wandWrapper.getRodName(), k -> new HashMap<>())
+        rodTagToWrapper.computeIfAbsent(wandWrapper.getRodName(), k -> new HashMap<>())
                 .put(wandWrapper instanceof SceptreWrapper, wandWrapper);
     }
 

--- a/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
@@ -11,7 +11,6 @@ import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
 
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.wands.IWandRodOnUpdate;
 import thaumcraft.api.wands.StaffRod;
 import thaumcraft.api.wands.WandCap;
@@ -58,22 +57,10 @@ public class TCWandAPI {
         caps.add(cap);
     }
 
+    @SuppressWarnings("unchecked")
     private static void makeWands() {
-        for (AbstractWandWrapper wandWrapper : wandWrappers) {
-            for (CapWrapper cap : caps) {
-                regRecipe(wandWrapper, cap);
-            }
-        }
-    }
-
-    private static void regRecipe(AbstractWandWrapper wandWrapper, CapWrapper cap) {
-        AspectList aspects = new AspectList();
-        for (Aspect a : Aspect.getPrimalAspects()) {
-            aspects.add(a, wandWrapper.getRecipeCost(cap));
-        }
-
-        ItemStack wand = wandWrapper.getItem(cap);
-        ThaumcraftApi.addArcaneCraftingRecipe(wandWrapper.getResearchName(), wand, aspects, wandWrapper.genRecipe(cap));
+        ThaumcraftApi.getCraftingRecipes().add(new GTNHWandRecipe());
+        ThaumcraftApi.getCraftingRecipes().add(new GTNHScepterRecipe());
     }
 
     /**

--- a/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/TCWandAPI.java
@@ -26,7 +26,8 @@ public class TCWandAPI {
 
     private static final ArrayList<IWandRegistry> registries = new ArrayList<>();
     private static final ArrayList<AbstractWandWrapper> wandWrappers = new ArrayList<>();
-    private static final Map<String, Map<Boolean, AbstractWandWrapper>> rodTagToWrapper = new HashMap<>();
+    private static final Map<String, AbstractWandWrapper> rodTagToWand = new HashMap<>();
+    private static final Map<String, AbstractWandWrapper> rodTagToScepter = new HashMap<>();
     private static final ArrayList<CapWrapper> caps = new ArrayList<>();
     private static final HashMap<String, CapWrapper> capTagToWrapper = new HashMap<>();
 
@@ -54,8 +55,11 @@ public class TCWandAPI {
      */
     public static void regWandWrapper(AbstractWandWrapper wandWrapper) {
         wandWrappers.add(wandWrapper);
-        rodTagToWrapper.computeIfAbsent(wandWrapper.getRodName(), k -> new HashMap<>())
-                .put(wandWrapper instanceof SceptreWrapper, wandWrapper);
+        if (wandWrapper instanceof SceptreWrapper) {
+            rodTagToScepter.put(wandWrapper.getRodName(), wandWrapper);
+        } else {
+            rodTagToWand.put(wandWrapper.getRodName(), wandWrapper);
+        }
     }
 
     /**
@@ -144,8 +148,10 @@ public class TCWandAPI {
     }
 
     public static AbstractWandWrapper getWrapperForRod(String tag, boolean scepter) {
-        Map<Boolean, AbstractWandWrapper> inner = rodTagToWrapper.get(tag);
-        return inner != null ? inner.get(scepter) : null;
+        if (scepter) {
+            return rodTagToScepter.get(tag);
+        }
+        return rodTagToWand.get(tag);
     }
 
     public static AbstractWandWrapper getWrapperForRod(ItemStack item, boolean scepter) {

--- a/src/main/java/com/gtnewhorizons/tcwands/api/WandRecipeCreator.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/WandRecipeCreator.java
@@ -95,7 +95,7 @@ public class WandRecipeCreator {
      * Register staff recipe with provided base, cap cost and with level one higher tier and its standard conductor.
      */
     public WandRecipeCreator regUpwardStaffRecipe(int baseCost, int capCost) {
-        GTTier tier = wandDetails.getTier().nextTier();
+        GTTier tier = wandDetails.tier().nextTier();
         return regStaffRecipe(baseCost, capCost, tier);
     }
 

--- a/src/main/java/com/gtnewhorizons/tcwands/api/WandRecipeCreator.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/WandRecipeCreator.java
@@ -11,7 +11,7 @@ import com.gtnewhorizons.tcwands.api.wrappers.*;
  */
 public class WandRecipeCreator {
 
-    private String name;
+    private final String name;
     private WandDetails wandDetails = null;
     private WandDetails staffDetails = null;
     private WandProps wandProps = null;
@@ -156,7 +156,7 @@ public class WandRecipeCreator {
 
     private void applyCustomizations(AbstractWandWrapper wandWrapper) {
         if (customResearchName != null) {
-            wandWrapper.setCustomResearchName(customResearchName);
+            wandWrapper.setResearch(customResearchName);
             customResearchName = null;
         }
 

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandDetails.java
@@ -2,36 +2,16 @@ package com.gtnewhorizons.tcwands.api.wandinfo;
 
 import net.minecraft.item.ItemStack;
 
+import com.github.bsideup.jabel.Desugar;
 import com.gtnewhorizons.tcwands.api.GTTier;
 
 import gregtech.api.enums.Materials;
 
-public class WandDetails {
-
-    private final String name;
-    private final GTTier tier;
-    private final ItemStack conductor;
-
-    public WandDetails(String name, GTTier tier, ItemStack conductor) {
-        this.name = name;
-        this.tier = tier;
-        this.conductor = conductor;
-    }
-
-    public ItemStack getConductor() {
-        return conductor;
-    }
-
-    public String getName() {
-        return name;
-    }
+@Desugar
+public record WandDetails(String name, GTTier tier, ItemStack conductor) {
 
     public Materials getMaterial() {
         return tier.getMaterial();
-    }
-
-    public GTTier getTier() {
-        return tier;
     }
 
     public String getScrew() {

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandProps.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wandinfo/WandProps.java
@@ -1,19 +1,6 @@
 package com.gtnewhorizons.tcwands.api.wandinfo;
 
-public class WandProps {
+import com.github.bsideup.jabel.Desugar;
 
-    private int baseCost, capCost;
-
-    public WandProps(int baseCost, int capCost) {
-        this.baseCost = baseCost;
-        this.capCost = capCost;
-    }
-
-    public int getCapCost() {
-        return capCost;
-    }
-
-    public int getBaseCost() {
-        return baseCost;
-    }
-}
+@Desugar
+public record WandProps(int baseCost, int capCost) {}

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/AbstractWandWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/AbstractWandWrapper.java
@@ -9,6 +9,9 @@ import com.gtnewhorizons.tcwands.api.WandType;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandDetails;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandProps;
 
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.ShapedArcaneRecipe;
 import thaumcraft.api.wands.WandRod;
 import thaumcraft.common.config.ConfigItems;
 
@@ -46,6 +49,33 @@ public abstract class AbstractWandWrapper {
         wand.setItemDamage(getRecipeCost(cap));
 
         return wand;
+    }
+
+    public ShapedArcaneRecipe getRecipe(CapWrapper cap) {
+        ItemStack wand = getItem(cap);
+        AspectList vis = new AspectList();
+        int cost = getRecipeCost(cap);
+        for (Aspect a : Aspect.getPrimalAspects()) {
+            vis.add(a, cost);
+        }
+        ItemStack conductor = wandDetails.getConductor();
+        String screw = wandDetails.getScrew();
+        ItemStack capItem = cap.getItem();
+        return new ShapedArcaneRecipe(
+                null,
+                wand,
+                vis,
+                "XSC",
+                "SRS",
+                "CSX",
+                'X',
+                conductor,
+                'S',
+                screw,
+                'C',
+                capItem,
+                'R',
+                craftingRod);
     }
 
     protected NBTTagCompound writeNBT(CapWrapper cap) {

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/AbstractWandWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/AbstractWandWrapper.java
@@ -58,7 +58,7 @@ public abstract class AbstractWandWrapper {
         for (Aspect a : Aspect.getPrimalAspects()) {
             vis.add(a, cost);
         }
-        ItemStack conductor = wandDetails.getConductor();
+        ItemStack conductor = wandDetails.conductor();
         String screw = wandDetails.getScrew();
         ItemStack capItem = cap.getItem();
         return new ShapedArcaneRecipe(
@@ -87,7 +87,7 @@ public abstract class AbstractWandWrapper {
     }
 
     public int getRecipeCost(CapWrapper cap) {
-        return wandProps.getBaseCost() + wandProps.getCapCost() * cap.getCostMultiplier();
+        return wandProps.baseCost() + wandProps.capCost() * cap.getCostMultiplier();
     }
 
     public WandProps getProps() {
@@ -118,6 +118,6 @@ public abstract class AbstractWandWrapper {
     }
 
     public String getRodName() {
-        return wandDetails.getName();
+        return wandDetails.name();
     }
 }

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/AbstractWandWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/AbstractWandWrapper.java
@@ -14,10 +14,10 @@ import thaumcraft.common.config.ConfigItems;
 
 public abstract class AbstractWandWrapper {
 
-    private WandDetails wandDetails;
-    private WandProps wandProps;
+    private final WandDetails wandDetails;
+    private final WandProps wandProps;
 
-    private String customResearchName;
+    private String research;
     /**
      * Item that will be used in recipe at the place of rod.
      */
@@ -34,6 +34,7 @@ public abstract class AbstractWandWrapper {
                         + ". Be careful to register your custom rod before creating recipes.");
 
         this.craftingRod = wandRod.getItem();
+        this.research = wandRod.getResearch();
     }
 
     public ItemStack getItem(CapWrapper cap) {
@@ -59,8 +60,6 @@ public abstract class AbstractWandWrapper {
         return wandProps.getBaseCost() + wandProps.getCapCost() * cap.getCostMultiplier();
     }
 
-    public abstract Object[] genRecipe(CapWrapper cap);
-
     public WandProps getProps() {
         return wandProps;
     }
@@ -69,17 +68,15 @@ public abstract class AbstractWandWrapper {
         return wandDetails;
     }
 
-    protected abstract String getDefaultResearchName();
-
     @NotNull
     public abstract WandType getType();
 
     public String getResearchName() {
-        return customResearchName != null ? customResearchName : getDefaultResearchName();
+        return research;
     }
 
-    public void setCustomResearchName(String customResearchName) {
-        this.customResearchName = customResearchName;
+    public void setResearch(String research) {
+        this.research = research;
     }
 
     public void setCustomCraftingRod(ItemStack rod) {

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/CapWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/CapWrapper.java
@@ -4,9 +4,10 @@ import net.minecraft.item.ItemStack;
 
 public class CapWrapper {
 
-    private int costMultiplier;
-    private String name;
-    private ItemStack itemStack;
+    private final int costMultiplier;
+    private final String name;
+    private final ItemStack itemStack;
+    private String research;
 
     public CapWrapper(String name, int costMultiplier) {
         this(name, thaumcraft.api.wands.WandCap.caps.get(name).getItem(), costMultiplier);
@@ -16,6 +17,7 @@ public class CapWrapper {
         this.name = name;
         this.costMultiplier = costMultiplier;
         this.itemStack = itemStack;
+        this.research = "CAP_" + name;
     }
 
     public String getName() {
@@ -28,5 +30,13 @@ public class CapWrapper {
 
     public ItemStack getItem() {
         return itemStack;
+    }
+
+    public String getResearch() {
+        return research;
+    }
+
+    public void setResearch(String research) {
+        this.research = research;
     }
 }

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/SceptreWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/SceptreWrapper.java
@@ -1,5 +1,6 @@
 package com.gtnewhorizons.tcwands.api.wrappers;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 import org.jetbrains.annotations.NotNull;
@@ -7,6 +8,11 @@ import org.jetbrains.annotations.NotNull;
 import com.gtnewhorizons.tcwands.api.WandType;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandDetails;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandProps;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.ShapedArcaneRecipe;
+import thaumcraft.common.config.ConfigItems;
 
 public class SceptreWrapper extends AbstractWandWrapper {
 
@@ -37,5 +43,35 @@ public class SceptreWrapper extends AbstractWandWrapper {
     @Override
     public @NotNull WandType getType() {
         return WandType.SCEPTRE;
+    }
+
+    @Override
+    public ShapedArcaneRecipe getRecipe(CapWrapper cap) {
+        ItemStack wand = getItem(cap);
+        AspectList vis = new AspectList();
+        int cost = getRecipeCost(cap);
+        for (Aspect a : Aspect.getPrimalAspects()) {
+            vis.add(a, cost);
+        }
+        ItemStack conductor = getDetails().getConductor();
+        String screw = getDetails().getScrew();
+        ItemStack capItem = cap.getItem();
+        return new ShapedArcaneRecipe(
+                null,
+                wand,
+                vis,
+                "XCP",
+                "SRC",
+                "CSX",
+                'X',
+                conductor,
+                'S',
+                screw,
+                'C',
+                capItem,
+                'R',
+                getCraftingRod(),
+                'P',
+                new ItemStack(ConfigItems.itemResource, 1, 15));
     }
 }

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/SceptreWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/SceptreWrapper.java
@@ -53,7 +53,7 @@ public class SceptreWrapper extends AbstractWandWrapper {
         for (Aspect a : Aspect.getPrimalAspects()) {
             vis.add(a, cost);
         }
-        ItemStack conductor = getDetails().getConductor();
+        ItemStack conductor = getDetails().conductor();
         String screw = getDetails().getScrew();
         ItemStack capItem = cap.getItem();
         return new ShapedArcaneRecipe(

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/SceptreWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/SceptreWrapper.java
@@ -1,6 +1,5 @@
 package com.gtnewhorizons.tcwands.api.wrappers;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
 import org.jetbrains.annotations.NotNull;
@@ -9,11 +8,9 @@ import com.gtnewhorizons.tcwands.api.WandType;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandDetails;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandProps;
 
-import thaumcraft.common.config.ConfigItems;
-
 public class SceptreWrapper extends AbstractWandWrapper {
 
-    private float sceptreCostMultiplier;
+    private final float sceptreCostMultiplier;
 
     public SceptreWrapper(WandDetails wandDetails, WandProps wandProps, float sceptreCostMultiplier) {
         super(wandDetails, wandProps);
@@ -35,19 +32,6 @@ public class SceptreWrapper extends AbstractWandWrapper {
     @Override
     public int getRecipeCost(CapWrapper cap) {
         return (int) (super.getRecipeCost(cap) * sceptreCostMultiplier);
-    }
-
-    @Override
-    public Object[] genRecipe(CapWrapper cap) {
-        return new Object[] { "MCP", "SRC", "CSM", 'R', getCraftingRod(), 'M', getDetails().getConductor(), 'S',
-                getDetails().getScrew(), 'C', cap.getItem(), 'P', new ItemStack(ConfigItems.itemResource, 1, 15) // Primal
-                                                                                                                 // Charm
-        };
-    }
-
-    @Override
-    public String getDefaultResearchName() {
-        return "SCEPTRE";
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/StaffWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/StaffWrapper.java
@@ -1,14 +1,10 @@
 package com.gtnewhorizons.tcwands.api.wrappers;
 
-import net.minecraft.item.ItemStack;
-
 import org.jetbrains.annotations.NotNull;
 
 import com.gtnewhorizons.tcwands.api.WandType;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandDetails;
 import com.gtnewhorizons.tcwands.api.wandinfo.WandProps;
-
-import thaumcraft.common.config.ConfigItems;
 
 public class StaffWrapper extends AbstractWandWrapper {
 
@@ -17,21 +13,8 @@ public class StaffWrapper extends AbstractWandWrapper {
     }
 
     @Override
-    public Object[] genRecipe(CapWrapper cap) {
-        return new Object[] { "MSC", "SRS", "CSM", 'R', getCraftingRod(), 'M', getDetails().getConductor(), 'S',
-                getDetails().getScrew(), 'C', cap.getItem(), 'P', new ItemStack(ConfigItems.itemResource, 1, 15) // Primal
-                                                                                                                 // Charm
-        };
-    }
-
-    @Override
     public String getRodName() {
         return super.getRodName() + "_staff";
-    }
-
-    @Override
-    public String getDefaultResearchName() {
-        return "ROD_greatwood_staff";
     }
 
     @Override

--- a/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/WandWrapper.java
+++ b/src/main/java/com/gtnewhorizons/tcwands/api/wrappers/WandWrapper.java
@@ -20,17 +20,6 @@ public class WandWrapper extends AbstractWandWrapper {
     }
 
     @Override
-    public Object[] genRecipe(CapWrapper cap) {
-        return new Object[] { "MSC", "SRS", "CSM", 'R', getCraftingRod(), 'M', getDetails().getConductor(), 'S',
-                getDetails().getScrew(), 'C', cap.getItem() };
-    }
-
-    @Override
-    public String getDefaultResearchName() {
-        return "BASICTHAUMATURGY";
-    }
-
-    @Override
     public @NotNull WandType getType() {
         return WandType.WAND;
     }


### PR DESCRIPTION
Rather than pre-baking over a thousand recipes in the full pack and adding them all to the list of thaum's crafting recipes (which are all iterated very often), now only two recipes are registered which handle all wand crafting.

One handles wands/staves and the other handles scepters/staffters.

As part of these changes, the researches for rods and caps are now required when they weren't before. It uses Salis Arcana's IMultipleResearchArcaneRecipe (when the mod is present) to show them when they are missing:
<img width="956" height="704" alt="image" src="https://github.com/user-attachments/assets/df66a55d-2c53-4047-b5bf-53a83c114fab" />
<img width="968" height="724" alt="image" src="https://github.com/user-attachments/assets/b1c639f3-8e42-4c0a-b69a-7d40b3bc659a" />
<img width="970" height="715" alt="image" src="https://github.com/user-attachments/assets/d942ba4c-030d-43c2-92a1-a4679c0f15a5" />
<img width="960" height="701" alt="image" src="https://github.com/user-attachments/assets/05501348-4eca-4c0c-ae16-a8ecc70a77e3" />

The following mods need further fixes because of this change:

Coremod's Thaumcraft script crashes when trying to load into a world. It looks like it's trying to find the old recipes to register research pages for them.
Aspect Recipe Index will need to be updated to account for this change. It currently can't find any of the recipes for the wands, which is expected.